### PR TITLE
Fix for Zip Path Traversal Vulnerability.

### DIFF
--- a/src/android/FiNe/Zeep.java
+++ b/src/android/FiNe/Zeep.java
@@ -109,6 +109,10 @@ public class Zeep extends CordovaPlugin
                 try
                 {
                     File file = new File(toFile, entry.getName());
+                    String canonicalPath = file.getCanonicalPath();
+                    if (!canonicalPath.startsWith(toFile.getCanonicalPath())) {
+                        throw new Exception(String.format("Found Zip Path Traversal Vulnerability with %s", canonicalPath));
+                    }
                     file.getParentFile().mkdirs();
                     if (!entry.isDirectory()) 
                      { 


### PR DESCRIPTION
Google Play Store is not accepting submissions that have Zip Path Traversal Vulnerability. Details on how to fix was provided in this link https://support.google.com/faqs/answer/9294009. Following the same procedure, **Zip Path Traversal Vulnerability** in **cordova-plugin-zeep** plugin is addressed. Please merge this and push a new release to npm.