### PR TITLE
Remove version constraint for cordova-plugin-file dependency on plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -9,8 +9,6 @@
     <repo>https://github.com/FortuneN/cordova-plugin-zeep.git</repo>
     <issue>https://github.com/FortuneN/cordova-plugin-zeep/issues</issue>
 
-    <dependency id="cordova-plugin-file" version=">=2.0.0" />
-
     <js-module name="Zeep" src="www/Zeep.js">
         <clobbers target="window.Zeep" />
     </js-module>


### PR DESCRIPTION
## Overview
This pull request removes the version constraint from the `cordova-plugin-file` dependency in `plugin.xml`. This change aims to resolve an issue where the `-OS5` suffix in the plugin version causes dependency resolution problems with Cordova's versioning system.

## Problem
The current version constraint for `cordova-plugin-file` (`>=2.0.0`) does not accommodate versions with a suffix like `-OS5`. As a result, Cordova's dependency resolution fails even when the installed plugin version (`6.0.2-OS5`) should satisfy the specified constraint. This issue has been causing build failures for projects that rely on this specific version of the plugin.

## Solution
By removing the explicit version constraint from the `plugin.xml` file, we allow the Cordova build process to proceed with the installed version of `cordova-plugin-file`, regardless of suffixes. This change is particularly important for environments that require the `-OS5` variant and cannot switch to a version without the suffix.

## Testing
The removal of the version constraint has been tested locally to ensure that the Cordova build process completes successfully with the `6.0.2-OS5` version of `cordova-plugin-file`. Further testing by other contributors is welcome to ensure that this change does not adversely affect other environments or use cases.

## Backward Compatibility
This change should not affect backward compatibility as it simply broadens the range of acceptable versions for `cordova-plugin-file`. Projects that do not use the `-OS5` variant will continue to resolve their dependencies as before.

Please review this change and consider merging it to help projects that rely on the `-OS5` version of `cordova-plugin-file`. Thank you for your time and consideration.